### PR TITLE
Export `window.React` so that the react-devtools can find it.

### DIFF
--- a/templates/javascript/App.jsx
+++ b/templates/javascript/App.jsx
@@ -7,6 +7,9 @@
 var React = require('react/addons');
 var ReactTransitionGroup = React.addons.TransitionGroup;
 
+// Export React so the devtools can find it
+(window !== window.top ? window.top : window).React = React;
+
 // CSS
 require('../../styles/reset.css');
 require('../../styles/main.css');


### PR DESCRIPTION
The chrome tools first looks to see if `React` is defined globally, then if it's available via a call to `require()`. See https://github.com/facebook/react-devtools/blob/master/injected/ReactHost.js#L42-L48
