### PR TITLE
Add missing resolve section

### DIFF
--- a/templates/common/root/webpack.dist.config.js
+++ b/templates/common/root/webpack.dist.config.js
@@ -31,6 +31,10 @@ module.exports = {
     new webpack.optimize.AggressiveMergingPlugin()
   ],
 
+  resolve: {
+    extensions: ['','.js','.jsx']
+  },
+
   module: {
     preLoaders: [{
       test: '\\.js$',


### PR DESCRIPTION
The webpack.dist.config.js was missing a resolve section. That resulted in this issue I reported earlier today: https://github.com/newtriks/generator-react-webpack/issues/22.

With this change 'grunt build' works flaelessly
