### PR TITLE
Update karma-webpack depency to fix confusing error

### DIFF
--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -30,7 +30,7 @@
     "karma-phantomjs-launcher": "~0.1.3",
     "karma": "~0.12.21",
     "grunt-karma": "~0.8.3",
-    "karma-webpack-plugin": "~1.0.0",
+    "karma-webpack": "~1.2.2",
     "webpack-dev-server": "~1.6.5",
     "grunt-open": "~0.2.3",
     "jshint-loader": "~0.8.0",


### PR DESCRIPTION
Using karma-webpack-plugin 1.0.0 led to the following error from grunt
test immediately after generating.  I found the following fix in
karma-webpack that had not been included in karma-webpack-plugin because
it has since become karma-webpack.

error:
INFO [PhantomJS 1.9.7 (Mac OS X)]: Connected on socket 33J3dAUsvdMT6Io38nxm with id 51124214
PhantomJS 1.9.7 (Mac OS X) ERROR
  TEST RUN WAS CANCELLED because this file contains some errors:
      /.../eventlist/test/spec/components/EventlistApp.js

fix:
https://github.com/webpack/karma-webpack/commit/ad3be8452f4debd954256cffcb9ffd84f2b838d6
