### PR TITLE
fix the require's style path when creating sub-foldered components

### DIFF
--- a/templates/javascript/Component.js
+++ b/templates/javascript/Component.js
@@ -2,11 +2,11 @@
 
 var React = require('react/addons');
 
-<% if (stylesLanguage === 'css') { %>require('../../styles/<%= classedName %>.css');<% } %><%
-if (stylesLanguage === 'sass')   { %>require('../../styles/<%= classedName %>.sass');<% } %><%
-if (stylesLanguage === 'scss')   { %>require('../../styles/<%= classedName %>.scss');<% } %><%
-if (stylesLanguage === 'less')   { %>require('../../styles/<%= classedName %>.less');<% } %><%
-if (stylesLanguage === 'stylus') { %>require('../../styles/<%= classedName %>.styl');<% } %>
+<% if (stylesLanguage === 'css') { %>require('../../styles/<%= classedFileName %>.css');<% } %><%
+if (stylesLanguage === 'sass')   { %>require('../../styles/<%= classedFileName %>.sass');<% } %><%
+if (stylesLanguage === 'scss')   { %>require('../../styles/<%= classedFileName %>.scss');<% } %><%
+if (stylesLanguage === 'less')   { %>require('../../styles/<%= classedFileName %>.less');<% } %><%
+if (stylesLanguage === 'stylus') { %>require('../../styles/<%= classedFileName %>.styl');<% } %>
 
 var <%= classedName %> = React.createClass({
   render: function () {


### PR DESCRIPTION
Currently `yo react-webpack:component Foo/Bar/Blam` will create a component with a style file `styles/Foo/Bar/Blam.scss`, but the component file has a require path of `'../../styles/Blam.scss'`.