### PR TITLE
6to5 rename to Babel

### DIFF
--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -35,8 +35,8 @@
     "grunt-open": "~0.2.3",
     "jshint-loader": "~0.8.0",
     "grunt-contrib-copy": "~0.5.0",<% if (es6) { %>
-    "6to5": "^2.7.1",
-    "6to5-loader": "^1.0.0",<% } %>
+    "babel": "^4.0.0",
+    "babel-loader": "^4.0.0",<% } %>
     "grunt-contrib-clean": "~0.6.0",<% if (stylesLanguage.match(/s[ac]ss/)) { %>
     "sass-loader": "^0.3.1",<% } %><% if (stylesLanguage === 'less') { %>
     "less-loader": "^2.0.0",<% } %><% if (stylesLanguage === 'stylus') { %>

--- a/templates/common/_webpack.config.js
+++ b/templates/common/_webpack.config.js
@@ -38,7 +38,7 @@ module.exports = {
     }],
     loaders: [{
       test: /\.js$/,
-      loader: 'react-hot!<% if (es6) { %>6to5!<% }%>jsx-loader?harmony'
+      loader: 'react-hot!<% if (es6) { %>babel!<% }%>jsx-loader?harmony'
     },<% if (stylesLanguage === 'sass') { %> {
       test: /\.sass/,
       loader: 'style-loader!css-loader!sass-loader?outputStyle=expanded'

--- a/templates/common/_webpack.dist.config.js
+++ b/templates/common/_webpack.dist.config.js
@@ -45,7 +45,7 @@ module.exports = {
 
     loaders: [{
       test: /\.js$/,
-      loader: '<% if (es6) { %>6to5!<% }%>jsx-loader?harmony'
+      loader: '<% if (es6) { %>babel!<% }%>jsx-loader?harmony'
     }, {
       test: /\.css$/,
       loader: 'style-loader!css-loader'

--- a/templates/common/karma.conf.js
+++ b/templates/common/karma.conf.js
@@ -25,7 +25,7 @@ module.exports = function (config) {
           loader: 'url-loader?limit=10000&mimetype=image/png'
         }, {
           test: /\.js$/,
-          loader: '<% if (es6) { %>6to5!<% }%>jsx-loader?harmony'
+          loader: '<% if (es6) { %>babel!<% }%>jsx-loader?harmony'
         },<% if (stylesLanguage === 'sass') { %> {
           test: /\.sass/,
           loader: 'style-loader!css-loader!sass-loader?outputStyle=expanded'


### PR DESCRIPTION
6to5 has been renamed to Babel. (See https://github.com/6to5/6to5)
This updates dependencies to reflect the name change.