### PR TITLE
remove unnecessary conditional?

### DIFF
--- a/templates/javascript/App.js
+++ b/templates/javascript/App.js
@@ -4,7 +4,7 @@ var React = require('react/addons');
 var ReactTransitionGroup = React.addons.TransitionGroup;
 
 // Export React so the devtools can find it
-(window !== window.top ? window.top : window).React = React;
+window.top.React = React;
 
 // CSS
 require('../../styles/normalize.css');


### PR DESCRIPTION
I might be missing something, but AFAICT the conditional means setting window.top.React when window and window.top are different, and window.React when they're the same.  In the latter case, since they're the same, setting window.React is the same as setting window.top.React, so it seems like you could just remove the conditional and always set window.top.React instead?