### PR TITLE
Fix jshint preloader

### DIFF
--- a/templates/common/_webpack.config.js
+++ b/templates/common/_webpack.config.js
@@ -32,8 +32,8 @@ module.exports = {
   },
   module: {
     preLoaders: [{
-      test: '\\.js$',
-      exclude: 'node_modules',
+      test: /\.js$/,
+      exclude: /node_modules/,
       loader: 'jshint'
     }],
     loaders: [{

--- a/templates/common/_webpack.dist.config.js
+++ b/templates/common/_webpack.dist.config.js
@@ -38,8 +38,8 @@ module.exports = {
 
   module: {
     preLoaders: [{
-      test: '\\.js$',
-      exclude: 'node_modules',
+      test: /\.js$/,
+      exclude: /node_modules/,
       loader: 'jshint'
     }],
 


### PR DESCRIPTION
The `test` and `exclude` properties had the wrong syntax; they needed to be RegExps not strings.