### PR TITLE
Exclude node_modules from js loaders

### DIFF
--- a/templates/common/_webpack.config.js
+++ b/templates/common/_webpack.config.js
@@ -38,6 +38,7 @@ module.exports = {
     }],
     loaders: [{
       test: /\.js$/,
+      exclude: /node_modules/,
       loader: 'react-hot!<% if (es6) { %>6to5!<% }%>jsx-loader?harmony'
     },<% if (stylesLanguage === 'sass') { %> {
       test: /\.sass/,

--- a/templates/common/_webpack.dist.config.js
+++ b/templates/common/_webpack.dist.config.js
@@ -45,6 +45,7 @@ module.exports = {
 
     loaders: [{
       test: /\.js$/,
+      exclude: /node_modules/,
       loader: '<% if (es6) { %>6to5!<% }%>jsx-loader?harmony'
     }, {
       test: /\.css$/,


### PR DESCRIPTION
Probably a good idea to exclude js files in `node_modules` from being run through loaders.