### PR TITLE
make jsx hint default to resolve warnings when compiling

### DIFF
--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -34,6 +34,7 @@
     "webpack-dev-server": "~1.6.5",
     "grunt-open": "~0.2.3",
     "jshint-loader": "~0.8.0",
+    "jsxhint-loader": "~0.2.0",
     "grunt-contrib-copy": "~0.5.0",<% if (es6) { %>
     "babel": "^4.0.0",
     "babel-loader": "^4.0.0",<% } %>

--- a/templates/common/_webpack.config.js
+++ b/templates/common/_webpack.config.js
@@ -34,7 +34,7 @@ module.exports = {
     preLoaders: [{
       test: /\.js$/,
       exclude: /node_modules/,
-      loader: 'jshint'
+      loader: 'jsxhint'
     }],
     loaders: [{
       test: /\.js$/,

--- a/templates/common/_webpack.dist.config.js
+++ b/templates/common/_webpack.dist.config.js
@@ -40,7 +40,7 @@ module.exports = {
     preLoaders: [{
       test: /\.js$/,
       exclude: /node_modules/,
-      loader: 'jshint'
+      loader: 'jsxhint'
     }],
 
     loaders: [{


### PR DESCRIPTION
I noticed the following warnings when using the default generator (not the component) and `grunt serve`. I resolved with the attached changes. Could you add a bit more to the README on how to run the tests for the generator itself? I'd be happy to add some tests if I can figure out how to run them :)

````
WARNING in ./src/scripts/components/main.js
jshint results in errors
  Unclosed regular expression. @ line 10 char 52
        <Route name="/" handler={MyApp}/>

  Unrecoverable syntax error. (58% scanned). @ line 10 char 52
    undefined

WARNING in ./src/scripts/components/MyApp.js
jshint results in errors
  Unclosed regular expression. @ line 17 char 31
              <img src={imageURL} />

  Unrecoverable syntax error. (68% scanned). @ line 17 char 31
    undefined
````