### PR TITLE
Use babel-loader instead of jsx-loader

### DIFF
--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -18,7 +18,6 @@
     "load-grunt-tasks": "~0.6.0",
     "grunt-contrib-connect": "~0.8.0",
     "webpack": "~1.4.3",
-    "jsx-loader": "~0.12.2",
     "grunt-webpack": "~1.0.8",
     "style-loader": "~0.8.0",
     "url-loader": "~0.5.5",
@@ -35,9 +34,9 @@
     "grunt-open": "~0.2.3",
     "jshint-loader": "~0.8.0",
     "jsxhint-loader": "~0.2.0",
-    "grunt-contrib-copy": "~0.5.0",<% if (es6) { %>
+    "grunt-contrib-copy": "~0.5.0",
     "babel": "^4.0.0",
-    "babel-loader": "^4.0.0",<% } %>
+    "babel-loader": "^4.0.0",
     "grunt-contrib-clean": "~0.6.0",<% if (stylesLanguage.match(/s[ac]ss/)) { %>
     "sass-loader": "^0.3.1",<% } %><% if (stylesLanguage === 'less') { %>
     "less-loader": "^2.0.0",<% } %><% if (stylesLanguage === 'stylus') { %>

--- a/templates/common/_webpack.config.js
+++ b/templates/common/_webpack.config.js
@@ -43,7 +43,7 @@ module.exports = {
     loaders: [{
       test: /\.js$/,
       exclude: /node_modules/,
-      loader: 'react-hot!<% if (es6) { %>babel!<% }%>jsx-loader?harmony'
+      loader: 'react-hot!babel-loader'
     },<% if (stylesLanguage === 'sass') { %> {
       test: /\.sass/,
       loader: 'style-loader!css-loader!sass-loader?outputStyle=expanded'

--- a/templates/common/_webpack.dist.config.js
+++ b/templates/common/_webpack.dist.config.js
@@ -50,7 +50,7 @@ module.exports = {
     loaders: [{
       test: /\.js$/,
       exclude: /node_modules/,
-      loader: '<% if (es6) { %>babel!<% }%>jsx-loader?harmony'
+      loader: 'babel-loader'
     }, {
       test: /\.css$/,
       loader: 'style-loader!css-loader'

--- a/templates/common/karma.conf.js
+++ b/templates/common/karma.conf.js
@@ -27,7 +27,7 @@ module.exports = function (config) {
           loader: 'url-loader?limit=10000&mimetype=image/png'
         }, {
           test: /\.js$/,
-          loader: '<% if (es6) { %>babel!<% }%>jsx-loader?harmony'
+          loader: 'babel-loader'
         },<% if (stylesLanguage === 'sass') { %> {
           test: /\.sass/,
           loader: 'style-loader!css-loader!sass-loader?outputStyle=expanded'


### PR DESCRIPTION
babel-loader also supports jsx, so let's use one common loader?