### PR TITLE
Sass loader now expects sass files to contain sass instead of scss

### DIFF
--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -42,7 +42,7 @@
     "babel": "^4.0.0",
     "babel-loader": "^4.0.0",
     "grunt-contrib-clean": "~0.6.0",<% if (stylesLanguage.match(/s[ac]ss/)) { %>
-    "sass-loader": "^0.3.1",<% } %><% if (stylesLanguage === 'less') { %>
+    "sass-loader": "^1.0.1",<% } %><% if (stylesLanguage === 'less') { %>
     "less-loader": "^2.0.0",<% } %><% if (stylesLanguage === 'stylus') { %>
     "stylus-loader": "^0.5.0",<% } %>
     "react-hot-loader": "^1.0.7"

--- a/templates/common/_webpack.config.js
+++ b/templates/common/_webpack.config.js
@@ -48,7 +48,7 @@ module.exports = {
       loader: 'react-hot!babel-loader'
     },<% if (stylesLanguage === 'sass') { %> {
       test: /\.sass/,
-      loader: 'style-loader!css-loader!sass-loader?outputStyle=expanded'
+      loader: 'style-loader!css-loader!sass-loader?outputStyle=expanded&indentedSyntax'
     },<% } %><% if (stylesLanguage === 'scss') { %> {
       test: /\.scss/,
       loader: 'style-loader!css-loader!sass-loader?outputStyle=expanded'

--- a/templates/common/_webpack.dist.config.js
+++ b/templates/common/_webpack.dist.config.js
@@ -58,7 +58,7 @@ module.exports = {
       loader: 'style-loader!css-loader'
     },<% if (stylesLanguage === 'sass') { %> {
       test: /\.sass/,
-      loader: 'style-loader!css-loader!sass-loader?outputStyle=expanded'
+      loader: 'style-loader!css-loader!sass-loader?outputStyle=expanded&indentedSyntax'
     },<% } %><% if (stylesLanguage === 'scss') { %> {
       test: /\.scss/,
       loader: 'style-loader!css-loader!sass-loader?outputStyle=expanded'


### PR DESCRIPTION
Hi there,

First of all, thanks for this great generator, it really kickstarted my experience with react & friends.

Unfortunately the sass loader needs to be reminded, that in `.sass` sass content is expected, so I added a small annotation. Additionally, as sass seems to have problems with the installation on OSX in this version number I updated it. So this PR should additionally fix #79 and #67 

Have a nice day! 