### PR TITLE
alias for generators, rich option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Generates a [JSX](http://facebook.github.io/react/docs/jsx-in-depth.html) compon
 
 Example:
 ```bash
-yo react-webpack:component foo
+yo react-webpack:component foo  //or just: yo react-webpack:c foo
 ```
 
 Produces `src/scripts/components/Foo.js` (*javascript - JSX*):
@@ -109,7 +109,7 @@ When using Flux or Reflux architecture, it generates an actionCreator in `src/sc
 
 Example:
 ```bash
-yo react-webpack:action bar
+yo react-webpack:action bar //or just: yo react-webpack:a bar
 ```
 Will create a file - `src/scripts/actions/BarActionCreators.js`
 
@@ -160,7 +160,7 @@ When using Flux or Reflux architecture, it generates a store in `src/scripts/sto
 
 Example:
 ```bash
-yo react-webpack:store baz
+yo react-webpack:store baz //or just: yo react-webpack:s baz
 ```
 Will create a file - `src/scripts/stores/BazStore.js`
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,45 @@ And `src/styles/Foo.css` (or .sass, .less etc...) :
 }
 ```
 
+### rich flag
+
+For all you lazy programmers out there, we've added another shortcut - `rich` flag:
+```bash
+yo react-webpack:c foofoo --rich 
+```
+This will give you all of react component's most common stuff :
+ ````
+ var React = require('react/addons');
+ 
+ require('styles/Foofoo.sass');
+ 
+ var Foofoo = React.createClass({
+   mixins: [],
+   getInitialState: function() { return({}) },
+   getDefaultProps: function() {},
+   componentWillMount: function() {},
+   componentDidMount: function() {},
+   shouldComponentUpdate: function() {},
+   componentDidUpdate: function() {},
+   componentWillUnmount: function() {},
+ 
+   render: function () {
+     return (
+         <div>
+           <p>Content for Foofoo</p>
+         </div>
+       );
+   }
+ });
+ 
+ module.exports = Foofoo; 
+ ````
+
+Just remove those you don't need, then fill and space out the rest. 
+
+
+
+
 ### Action
 
 When using Flux or Reflux architecture, it generates an actionCreator in `src/scripts/actions` and it's corresponding test in `src/spec/actions`.
@@ -237,6 +276,11 @@ Sets the style file's template and extension
 ### architecture
 
 [flux](https://facebook.github.io/flux/) or [reflux](https://github.com/spoike/refluxjs)
+
+### es6
+
+If you are using `es6`, and want to use its export functionality (and not webpack's), just add `--es6` flag when you create a component, action or srore.
+
 
 ## Testing
 

--- a/a/index.js
+++ b/a/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../action');

--- a/action/index.js
+++ b/action/index.js
@@ -3,8 +3,11 @@ var util = require('util');
 var ScriptBase = require('../script-base.js');
 
 var ActionGenerator = module.exports = function ActionGenerator(args, options, config) {
-  args[0] += 'ActionCreators';
-  ScriptBase.apply(this, arguments);
+  if (!args[0]) console.log('\n Please specify a name for this action creator \n');
+  else {
+    args[0] += 'ActionCreators';
+    ScriptBase.apply(this, arguments)
+  }
 };
 
 util.inherits(ActionGenerator, ScriptBase);

--- a/c/index.js
+++ b/c/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../component');

--- a/component/index.js
+++ b/component/index.js
@@ -13,6 +13,8 @@ ComponentGenerator.prototype.createComponentFile = function createComponentFile(
 
   this.es6 = this.options.es6;
 
+  console.log('Creating a component');
+
   this.generateComponentTestAndStyle(
     'Component',
     'spec/Component',

--- a/component/index.js
+++ b/component/index.js
@@ -10,8 +10,11 @@ util.inherits(ComponentGenerator, ScriptBase);
 
 ComponentGenerator.prototype.createComponentFile = function createComponentFile() {
   this.option('es6');
+  this.option('rich');
 
   this.es6 = this.options.es6;
+  this.rich = this.options.rich;
+  console.log(this.architecture)
 
   console.log('Creating a component');
 

--- a/component/index.js
+++ b/component/index.js
@@ -14,9 +14,6 @@ ComponentGenerator.prototype.createComponentFile = function createComponentFile(
 
   this.es6 = this.options.es6;
   this.rich = this.options.rich;
-  console.log(this.architecture)
-
-  console.log('Creating a component');
 
   this.generateComponentTestAndStyle(
     'Component',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "generator-react-webpack",
   "version": "1.2.1",
-  "description": "Yeoman generator for ReactJS and Webpack",
+  "description": "Yeoman generator for Facebook's ReactJS, with webpack, livereload, grunt, Flux/Reflux architecture options and support for sass, less or stylus  ",
   "keywords": [
     "yeoman-generator",
     "reactjs",

--- a/s/index.js
+++ b/s/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../store');

--- a/script-base.js
+++ b/script-base.js
@@ -82,7 +82,6 @@ Generator.prototype.testTemplate = function (src, dest) {
 };
 
 Generator.prototype.stylesTemplate = function (src, dest) {
-	console.log(src);
 	yeoman.generators.Base.prototype.template.apply(this, [
 		src + this.stylesSuffix,
 		path.join(this.options.stylesPath, dest) + this.stylesSuffix

--- a/store/index.js
+++ b/store/index.js
@@ -3,9 +3,12 @@ var util = require('util');
 var ScriptBase = require('../script-base.js');
 
 var StoreGenerator  = module.exports = function StoreGenerator(args, options, config) {
-  args[0] += 'Store';
-  ScriptBase.apply(this, arguments);
-}
+  if (!args[0]) console.log('\n Please specify a name for this store \n');
+  else {
+    args[0] += 'Store';
+    ScriptBase.apply(this, arguments)
+  }
+};
 
 util.inherits(StoreGenerator, ScriptBase);
 

--- a/templates/common/index.html
+++ b/templates/common/index.html
@@ -14,6 +14,10 @@
   <div id="content">
     <h1>If you can see this, something is broken (or JS is not enabled)!!.</h1>
   </div>
+
+  <script>
+    __REACT_DEVTOOLS_GLOBAL_HOOK__ = parent.__REACT_DEVTOOLS_GLOBAL_HOOK__
+  </script>
   <script type="text/javascript" src="assets/main.js"></script>
 </body>
 </html>

--- a/templates/javascript/Component.js
+++ b/templates/javascript/Component.js
@@ -1,6 +1,9 @@
 'use strict';
 
-var React = require('react/addons');
+var React = require('react/addons');<% if(rich && architecture === 'reflux'){%>
+var Reflux = require('Reflux'); <%}%>
+<% if(rich && architecture === 'flux' || architecture === 'reflux'){%>
+//var Actions = require('actions/xxx')<%}%>
 
 <% if (stylesLanguage === 'css') { %>require('styles/<%= classedFileName %>.css');<% } %><%
 if (stylesLanguage === 'sass')   { %>require('styles/<%= classedFileName %>.sass');<% } %><%
@@ -8,7 +11,16 @@ if (stylesLanguage === 'scss')   { %>require('styles/<%= classedFileName %>.scss
 if (stylesLanguage === 'less')   { %>require('styles/<%= classedFileName %>.less');<% } %><%
 if (stylesLanguage === 'stylus') { %>require('styles/<%= classedFileName %>.styl');<% } %>
 
-var <%= classedName %> = React.createClass({
+var <%= classedName %> = React.createClass({<% if(rich){%>
+  mixins: [<% if(architecture === 'reflux'){%>Reflux.ListenerMixin<%}%>],
+  getInitialState: function() { return({}) },
+  getDefaultProps: function() {},
+  componentWillMount: function() {},
+  componentDidMount: function() {},
+  shouldComponentUpdate: function() {},
+  componentDidUpdate: function() {},
+  componentWillUnmount: function() {},<%}%>
+
   render: function () {
     return (
         <div>


### PR DESCRIPTION
in this pull request:
1. alias for generators : `a`,`c`,`s` (action,store,component).
2. `rich` flag when generating a component.
3. protection against empty name in action/store generator (prev resulted :`UndefinedStore`)  
4. updated readme and description in package.json (that's what displayed in yeoman's site) 