### PR TITLE
Add grunt & grunt-cli to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "yeoman-generator": "^0.17.6"
   },
   "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
     "mocha": "^1.21.4",
     "underscore.string": "^2.3.3"
   },


### PR DESCRIPTION
This project assumes that the user has `grunt` installed, but that isn't always the case - this will make it easier for less experienced front-end developers to get up and running without having to separately install `grunt` and `grunt-cli`.

If you don't think this is a necessary addition to `package.json` we could always add a comment to the `README` instead?