### PR TITLE
Added architecture option for Alt (http://alt.js.org)

### DIFF
--- a/action/index.js
+++ b/action/index.js
@@ -24,6 +24,9 @@ ActionGenerator.prototype.createActionFile = function createActionFile() {
     case 'reflux':
           actionTemplate = 'RefluxAction';
           break;
+    case 'alt':
+          actionTemplate = 'AltAction';
+          break;
   }
 
   console.log('Creating ' + this.architecture + ' action');

--- a/app/index.js
+++ b/app/index.js
@@ -72,11 +72,12 @@ ReactWebpackGenerator.prototype.askForArchitecture  = function() {
   this.prompt({
     type    : 'list',
     name    : 'architecture',
-    message : 'Would you like to use one of those architectures?',
+    message : 'Would you like to use one of these architectures?',
     choices: [
       {name:'No need for that, thanks',value:false},
       {name:'Flux',value:'flux'},
-      {name:'ReFlux',value:'reflux'}
+      {name:'ReFlux',value:'reflux'},
+      {name:'Alt',value:'alt'}
     ],
     default : false
   }, function(props) {

--- a/main/index.js
+++ b/main/index.js
@@ -27,3 +27,9 @@ MainGenerator.prototype.createDispatcher = function createDispatcher() {
     this.appTemplate('Dispatcher', 'dispatcher/' + this.scriptAppName + 'Dispatcher');
   }
 };
+
+MainGenerator.prototype.createAltjsFile = function createAltjsFile() {
+  if(this.env.options.architecture=='alt') {
+    this.appTemplate('alt', 'alt');
+  }
+};

--- a/store/index.js
+++ b/store/index.js
@@ -26,6 +26,9 @@ StoreGenerator .prototype.createStoreFile  = function createStoreFile() {
     case 'reflux':
       storeTemplate = 'RefluxStore';
       break;
+    case 'alt':
+      storeTemplate = 'AltStore';
+      break;
   }
 
   console.log('Creating ' + this.architecture + ' store');

--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -14,7 +14,8 @@
     "flux": "^2.0.1",
     "events": "^1.0.2",
     "object-assign": "^2.0.0", <% } if (architecture === 'reflux') {%>
-    "reflux": "^0.2.7", <% } %>
+    "reflux": "^0.2.7", <% } if (architecture === 'alt') { %>
+    "alt": "^0.16.5", <% } %>
     "react": "~0.12.2",
     "normalize.css": "~3.0.3"
   },

--- a/templates/javascript/AltAction.js
+++ b/templates/javascript/AltAction.js
@@ -1,0 +1,11 @@
+var alt = require('../alt');
+
+<% if (es6) { %>class <%= classedName %> {
+
+}; <% }
+else { %>var <%= classedName %> = alt.createActions(function () {
+
+}); <% } %>
+
+<% if (es6) { %>export default alt.createActions(<%= classedName %>); <% }
+else { %>module.exports = <%= classedName %>; <% } %>

--- a/templates/javascript/AltStore.js
+++ b/templates/javascript/AltStore.js
@@ -1,0 +1,21 @@
+var alt = require('../alt');
+
+<% if (es6) { %>class <%= classedName %> {
+  constructor() {
+
+    this.bindListeners({
+
+    });
+
+  }
+} <% }
+else { %>var <%= classedName %> = alt.createStore({
+
+  bindListeners: {
+
+  }
+
+}); <% } %>
+
+<% if (es6) { %>export default alt.createStore(<%= classedName %>, '<%= classedName %>'); <% }
+else { %>module.exports = <%= classedName %>; <% } %>

--- a/templates/javascript/alt.js
+++ b/templates/javascript/alt.js
@@ -1,0 +1,4 @@
+var Alt = require('alt');
+var alt = new Alt();
+
+module.exports = alt;


### PR DESCRIPTION
Added architecture option for [Alt Flux library](https://github.com/goatslacker/alt) including sub-generators for actions and stores, supporting `--es6` flag too.