### PR TITLE
*ADD* Base: Added esLint as new linter

### DIFF
--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -21,6 +21,9 @@
   },
   "devDependencies": {
     "grunt": "~0.4.5",
+    "eslint": "^0.21.2",
+    "eslint-loader": "^0.11.2",
+    "eslint-plugin-react": "^2.4.0",
     "load-grunt-tasks": "~0.6.0",
     "grunt-contrib-connect": "~0.8.0",
     "webpack": "~1.4.3",
@@ -38,8 +41,6 @@
     "karma-webpack": "~1.2.2",
     "webpack-dev-server": "~1.6.5",
     "grunt-open": "~0.2.3",
-    "jshint-loader": "~0.8.0",
-    "jsxhint-loader": "~0.2.0",
     "grunt-contrib-copy": "~0.5.0",
     "babel": "^4.0.0",
     "babel-loader": "^4.0.0",

--- a/templates/common/_webpack.config.js
+++ b/templates/common/_webpack.config.js
@@ -41,7 +41,7 @@ module.exports = {
     preLoaders: [{
       test: /\.(js|jsx)$/,
       exclude: /node_modules/,
-      loader: 'jsxhint'
+      loader: 'eslint-loader'
     }],
     loaders: [{
       test: /\.(js|jsx)$/,
@@ -69,8 +69,7 @@ module.exports = {
   },
 
   plugins: [
-    new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin()
+    new webpack.HotModuleReplacementPlugin()
   ]
 
 };

--- a/templates/common/_webpack.dist.config.js
+++ b/templates/common/_webpack.dist.config.js
@@ -29,7 +29,8 @@ module.exports = {
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.UglifyJsPlugin(),
     new webpack.optimize.OccurenceOrderPlugin(),
-    new webpack.optimize.AggressiveMergingPlugin()
+    new webpack.optimize.AggressiveMergingPlugin(),
+    new webpack.NoErrorsPlugin()
   ],
 
   resolve: {
@@ -45,11 +46,10 @@ module.exports = {
 
   module: {
     preLoaders: [{
-      test: /\.js$/,
+      test: /\.(js|jsx)$/,
       exclude: /node_modules/,
-      loader: 'jsxhint'
+      loader: 'eslint-loader'
     }],
-
     loaders: [{
       test: /\.js$/,
       exclude: /node_modules/,

--- a/templates/common/root/.eslintrc
+++ b/templates/common/root/.eslintrc
@@ -1,0 +1,19 @@
+{
+  "plugins": [
+    "react"
+  ],
+  "ecmaFeatures": {
+    "jsx": true
+  },
+  "env": {
+    "browser": true,
+    "amd": true,
+    "es6": true
+  },
+  "rules": {
+    "quotes": [ 1, "single" ],
+    "no-undef": false,
+    "global-strict": false,
+    "no-extra-semi": 1
+  }
+}

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -101,7 +101,6 @@ describe('react-webpack generator', function() {
             ['Gruntfile.js', /hot:\s*true/],
             ['webpack.config.js', /react-hot/],
             ['webpack.config.js', /webpack\.HotModuleReplacementPlugin/],
-            ['webpack.config.js', /webpack\.NoErrorsPlugin/],
             ['webpack.config.js', /webpack\/hot\/only-dev-server/]
         ]);
         done();


### PR DESCRIPTION
Added eslint as new linter to webpack configuration. Please note that the webpack.NoErrorsPlugin does not work with eslint-loader correctly. Whenever eslint-loader throws an error or warning while using webpack.NoErrors, the build is suspended.

Therefore it was removed in the regular webpack.config, but included in the live version (because there it could be of value).

Please tell me what you think about it.