### PR TITLE
Remove trailing whitespace after Reflux

### DIFF
--- a/templates/javascript/Component.js
+++ b/templates/javascript/Component.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var React = require('react/addons');<% if(rich && architecture === 'reflux'){%>
-var Reflux = require('Reflux'); <%}%>
+var Reflux = require('Reflux');<%}%>
 <% if(rich && architecture === 'flux' || architecture === 'reflux'){%>
 //var Actions = require('actions/xxx')<%}%>
 


### PR DESCRIPTION
This fixes the linter error: `error  Trailing spaces not allowed  no-trailing-spaces`