### PR TITLE
Updates on karma test runner

### DIFF
--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -30,15 +30,15 @@
     "grunt-contrib-connect": "~0.8.0",
     "grunt-webpack": "~1.0.8",
     "jasmine-core": "^2.3.4",
-    "karma": "~0.12.21",
-    "karma-jasmine": "^0.3.5",
+    "karma": "~0.13.3",
+    "karma-jasmine": "^0.3.6",
     "karma-phantomjs-launcher": "~0.1.3",
     "karma-script-launcher": "~0.1.0",
-    "karma-webpack": "^1.5.0",
+    "karma-webpack": "^1.7.0",
     "style-loader": "~0.8.0",
     "url-loader": "~0.5.5",
     "css-loader": "~0.9.0",
-    "grunt-karma": "~0.8.3",
+    "grunt-karma": "~0.12.0",
     "grunt-open": "~0.2.3",
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-clean": "~0.6.0",<% if (stylesLanguage.match(/s[ac]ss/)) { %>
@@ -46,7 +46,7 @@
     "less-loader": "^2.0.0",<% } %><% if (stylesLanguage === 'stylus') { %>
     "stylus-loader": "^0.5.0",<% } %>
     "react-hot-loader": "^1.0.7",
-    "webpack": "~1.10.0",
-    "webpack-dev-server": "~1.10.0"
+    "webpack": "~1.10.5",
+    "webpack-dev-server": "~1.10.1"
   }
 }

--- a/templates/common/karma.conf.js
+++ b/templates/common/karma.conf.js
@@ -7,18 +7,10 @@ module.exports = function (config) {
     basePath: '',
     frameworks: ['jasmine'],
     files: [
-      'test/helpers/pack/**/*.js',
-      'test/helpers/react/**/*.js',
-      'test/spec/components/**/*.js'<% if(architecture === 'flux'||architecture === 'reflux') { %>,
-      'test/spec/stores/**/*.js',
-      'test/spec/actions/**/*.js'<% } %>
+      'test/spec/**/*.{js,jsx}'
     ],
     preprocessors: {
-      'test/helpers/createComponent.js': ['webpack'],
-      'test/spec/components/**/*.js': ['webpack'],
-      'test/spec/components/**/*.jsx': ['webpack']<% if(architecture === 'flux'||architecture === 'reflux') { %>,
-      'test/spec/stores/**/*.js': ['webpack'],
-      'test/spec/actions/**/*.js': ['webpack']<% } %>
+      'test/spec/**/*.{js,jsx}': ['webpack']
     },
     webpack: {
       cache: true,
@@ -79,11 +71,11 @@ module.exports = function (config) {
     port: 8080,
     logLevel: config.LOG_INFO,
     colors: true,
-    autoWatch: false,
+    autoWatch: true,
     browsers: ['PhantomJS'],
     reporters: ['dots'],
     captureTimeout: 60000,
-    singleRun: true,
+    singleRun: false,
     plugins: [
         require('karma-webpack'),
         require('karma-jasmine'),


### PR DESCRIPTION
- I've changed the karma files and preprocessors selector to a more generic one, so the user can reorganize the code structure without having to go back to karma.conf, also, adding the possibility of the specs files to use the .jsx extension.

- Changed karma `autoWatch` to true and `singleRun` to false, since development has a default auto-watch behavior, I'd expect the tests to run like that as well

- Karma wasn't working well with webpack, I had to update some dependencies to got everything going