### PR TITLE
Prevent two consecutive slashes in test imports #253

### DIFF
--- a/test/generators/component/indexTest.js
+++ b/test/generators/component/indexTest.js
@@ -18,7 +18,7 @@ describe('react-webpack:component', () => {
         fileName: 'src/styles/Mycomponent.css',
         expandedFileName: 'src/styles/my/littleSpecial/Test.css',
         assertions: {
-          componentImport: 'require(\'styles//Mycomponent.css\');',
+          componentImport: 'require(\'styles/Mycomponent.css\');',
           styleContent: '.mycomponent-component'
         }
       },
@@ -27,7 +27,7 @@ describe('react-webpack:component', () => {
         fileName: 'src/styles/Mycomponent.sass',
         expandedFileName: 'src/styles/my/littleSpecial/Test.sass',
         assertions: {
-          componentImport: 'require(\'styles//Mycomponent.sass\');',
+          componentImport: 'require(\'styles/Mycomponent.sass\');',
           styleContent: '.mycomponent-component'
         }
       },
@@ -36,7 +36,7 @@ describe('react-webpack:component', () => {
         fileName: 'src/styles/Mycomponent.scss',
         expandedFileName: 'src/styles/my/littleSpecial/Test.scss',
         assertions: {
-          componentImport: 'require(\'styles//Mycomponent.scss\');',
+          componentImport: 'require(\'styles/Mycomponent.scss\');',
           styleContent: '.mycomponent-component'
         }
       },
@@ -45,7 +45,7 @@ describe('react-webpack:component', () => {
         fileName: 'src/styles/Mycomponent.less',
         expandedFileName: 'src/styles/my/littleSpecial/Test.less',
         assertions: {
-          componentImport: 'require(\'styles//Mycomponent.less\');',
+          componentImport: 'require(\'styles/Mycomponent.less\');',
           styleContent: '.mycomponent-component'
         }
       },
@@ -54,7 +54,7 @@ describe('react-webpack:component', () => {
         fileName: 'src/styles/Mycomponent.styl',
         expandedFileName: 'src/styles/my/littleSpecial/Test.styl',
         assertions: {
-          componentImport: 'require(\'styles//Mycomponent.styl\');',
+          componentImport: 'require(\'styles/Mycomponent.styl\');',
           styleContent: '.mycomponent-component'
         }
       }
@@ -158,7 +158,7 @@ describe('react-webpack:component', () => {
 
           it('should create a unit test that imports the generated component', (done) => {
             createGeneratedComponent('mycomponent', style.type, options, () => {
-              assert.fileContent('test/components/MycomponentComponentTest.js', 'import MycomponentComponent from \'components//MycomponentComponent.js\';');
+              assert.fileContent('test/components/MycomponentComponentTest.js', 'import MycomponentComponent from \'components/MycomponentComponent.js\';');
               done();
             });
           });
@@ -197,7 +197,7 @@ describe('react-webpack:component', () => {
       },
       sass: {
         type: 'sass',
-        fileName: 'src/components/Mycomponent.cssmodule.sass',
+        fileName: 'src/components/mycomponent.cssmodule.sass',
         expandedFileName: 'src/components/my/littleSpecial/test.cssmodule.sass',
         assertions: {
           componentImport: 'import styles from \'./mycomponent.cssmodule.sass\';',
@@ -339,7 +339,7 @@ describe('react-webpack:component', () => {
 
           it('should create a unit test that imports the generated component', (done) => {
             createGeneratedComponent('mycomponent', style.type, options, () => {
-              assert.fileContent('test/components/MycomponentTest.js', 'import Mycomponent from \'components//Mycomponent.js\';');
+              assert.fileContent('test/components/MycomponentTest.js', 'import Mycomponent from \'components/Mycomponent.js\';');
               done();
             });
           });
@@ -411,7 +411,7 @@ describe('react-webpack:component', () => {
 
           it('should create a unit test that imports the generated component', (done) => {
             createGeneratedComponent('mycomponent', style.type, options, () => {
-              assert.fileContent('test/components/MycomponentTest.js', 'import Mycomponent from \'components//Mycomponent.js\';');
+              assert.fileContent('test/components/MycomponentTest.js', 'import Mycomponent from \'components/Mycomponent.js\';');
               done();
             });
           });

--- a/test/utils/yeomanTest.js
+++ b/test/utils/yeomanTest.js
@@ -69,7 +69,7 @@ describe('Utilities:Yeoman', () => {
 
     describe('when the generator version is set to 4', () => {
 
-      const expection = {
+      const expectionNamespaced = {
         style: {
           webpackPath: './test.cssmodule.css',
           path: 'src/components/my/component/',
@@ -91,9 +91,37 @@ describe('Utilities:Yeoman', () => {
         }
       };
 
+      const expectionRoot = {
+        style: {
+          webpackPath: './test.cssmodule.css',
+          path: 'src/components/',
+          fileName: 'test.cssmodule.css',
+          className: 'test-component',
+          suffix: '.css'
+        },
+        component: {
+          webpackPath: 'components/Test.js',
+          path: 'src/components/',
+          fileName: 'Test.js',
+          className: 'Test',
+          displayName: 'Test',
+          suffix: '.js'
+        },
+        test: {
+          path: 'test/components/',
+          fileName: 'TestTest.js'
+        }
+      };
+
       it('should get all required information for component creation from the components name', () => {
-        expect(utils.getAllSettingsFromComponentName('my/component/test', 'css', 4)).to.deep.equal(expection);
+        expect(utils.getAllSettingsFromComponentName('my/component/test', 'css', 4)).to.deep.equal(expectionNamespaced);
       });
+
+      it('should build path information wo/ two slashes when dealing with a non-namespaced component', () => {
+        expect(utils.getAllSettingsFromComponentName('test', 'css', 4)).to.deep.equal(expectionRoot);
+      });
+
+
     });
 
     describe('when the generator version is set to 3 (or not set at all)', () => {

--- a/utils/yeoman.js
+++ b/utils/yeoman.js
@@ -61,21 +61,21 @@ let getAllSettingsFromComponentName = (componentName, style, generatorVersion) =
       settings = {
         style: {
           webpackPath: `./${componentBaseName.toLowerCase()}.cssmodule${styleSettings.suffix}`,
-          path: `${componentPath.path}/${componentPartPath}/`,
+          path: path.normalize(`${componentPath.path}/${componentPartPath}/`),
           fileName: `${componentBaseName.toLowerCase()}.cssmodule${styleSettings.suffix}`,
           className: getComponentStyleName(componentBaseName),
           suffix: styleSettings.suffix
         },
         component: {
-          webpackPath: `components/${componentPartPath}/${componentBaseName}.js`,
-          path: `${componentPath.path}/${componentPartPath}/`,
+          webpackPath: path.normalize(`components/${componentPartPath}/${componentBaseName}.js`),
+          path: path.normalize(`${componentPath.path}/${componentPartPath}/`),
           fileName: `${componentBaseName}.js`,
           className: `${componentBaseName}`,
           displayName: `${componentFullName}`,
           suffix: '.js'
         },
         test: {
-          path: `${testPath.path}/components/${componentPartPath}/`,
+          path: path.normalize(`${testPath.path}/components/${componentPartPath}/`),
           fileName: `${componentBaseName}Test.js`
         }
       };
@@ -87,22 +87,22 @@ let getAllSettingsFromComponentName = (componentName, style, generatorVersion) =
     default:
       settings = {
         style: {
-          webpackPath: `styles/${componentPartPath}/${componentBaseName}${styleSettings.suffix}`,
-          path: `${stylePaths.path}/${componentPartPath}/`,
+          webpackPath: path.normalize(`styles/${componentPartPath}/${componentBaseName}${styleSettings.suffix}`),
+          path: path.normalize(`${stylePaths.path}/${componentPartPath}/`),
           fileName: `${componentBaseName}${styleSettings.suffix}`,
           className: getComponentStyleName(componentBaseName),
           suffix: styleSettings.suffix
         },
         component: {
-          webpackPath: `components/${componentPartPath}/${componentBaseName}Component.js`,
-          path: `${componentPath.path}/${componentPartPath}/`,
+          webpackPath: path.normalize(`components/${componentPartPath}/${componentBaseName}Component.js`),
+          path: path.normalize(`${componentPath.path}/${componentPartPath}/`),
           fileName: `${componentBaseName}Component.js`,
           className: `${componentBaseName}Component`,
           displayName: `${componentFullName}Component`,
           suffix: '.js'
         },
         test: {
-          path: `${testPath.path}/components/${componentPartPath}/`,
+          path: path.normalize(`${testPath.path}/components/${componentPartPath}/`),
           fileName: `${componentBaseName}ComponentTest.js`
         }
       };


### PR DESCRIPTION
Wrapped Node's `path.normalize()` around paths that have `componentPartPath` as a part segment. For non-namespaced components this segment can be empty which lead to two consecutive slashes in various places.

Updated test suite to assert against the updated import statements in various files.

PR for #253 